### PR TITLE
Implement Genre/Actor models and main operations

### DIFF
--- a/db/migrations/0001_initial.py
+++ b/db/migrations/0001_initial.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Genre',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Actor',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('first_name', models.CharField(max_length=255)),
+                ('last_name', models.CharField(max_length=255)),
+            ],
+        ),
+    ]

--- a/db/models.py
+++ b/db/models.py
@@ -1,1 +1,16 @@
 from django.db import models
+
+
+class Genre(models.Model):
+    name = models.CharField(max_length=255)
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class Actor(models.Model):
+    first_name = models.CharField(max_length=255)
+    last_name = models.CharField(max_length=255)
+
+    def __str__(self) -> str:
+        return f"{self.first_name} {self.last_name}"

--- a/main.py
+++ b/main.py
@@ -2,6 +2,30 @@ import init_django_orm  # noqa: F401
 
 from django.db.models import QuerySet
 
+from db.models import Genre, Actor
+
 
 def main() -> QuerySet:
-    pass
+    Genre.objects.create(name="Western")
+    Genre.objects.create(name="Action")
+    Genre.objects.create(name="Dramma")
+
+    Actor.objects.create(first_name="George", last_name="Klooney")
+    Actor.objects.create(first_name="Kianu", last_name="Reaves")
+    Actor.objects.create(first_name="Scarlett", last_name="Keegan")
+    Actor.objects.create(first_name="Will", last_name="Smith")
+    Actor.objects.create(first_name="Jaden", last_name="Smith")
+    Actor.objects.create(first_name="Scarlett", last_name="Johansson")
+
+    Genre.objects.filter(name="Dramma").update(name="Drama")
+    Actor.objects.filter(first_name="George", last_name="Klooney").update(
+        last_name="Clooney"
+    )
+    Actor.objects.filter(first_name="Kianu", last_name="Reaves").update(
+        first_name="Keanu", last_name="Reeves"
+    )
+
+    Genre.objects.filter(name="Action").delete()
+    Actor.objects.filter(first_name="Scarlett").delete()
+
+    return Actor.objects.filter(last_name="Smith").order_by("first_name")


### PR DESCRIPTION
## Summary
- add `Genre` and `Actor` models
- create an initial migration for them
- implement `main()` to create, update and delete records as required

## Testing
- `pytest -q` *(fails: unrecognized arguments --reuse-db)*

------
https://chatgpt.com/codex/tasks/task_e_68705a666fd88324ac038f41ffa01a15